### PR TITLE
feat: add color personalization for cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -195,6 +195,13 @@ body.dark-mode .message-card {
     margin-bottom: 0;
 }
 
+.card-controls {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+    align-items: center;
+}
+
 .copy-button {
     background-color: var(--accent-color);
     color: white;
@@ -232,6 +239,58 @@ body.dark-mode .message-card {
     0% { transform: scale(1); }
     50% { transform: scale(1.08); }
     100% { transform: scale(1); }
+}
+
+/* Color Picker Styles */
+.color-picker-control {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.color-picker-input {
+    width: 32px;
+    height: 32px;
+    border: 2px solid #ddd;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: border-color 0.2s;
+}
+
+.color-picker-input:hover {
+    border-color: var(--accent-color);
+}
+
+body.dark-mode .color-picker-input {
+    border-color: #30363d;
+}
+
+.color-reset-btn {
+    background: transparent;
+    border: 1px solid #ddd;
+    color: var(--text-color);
+    width: 32px;
+    height: 32px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-weight: 600;
+    transition: all 0.2s;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.color-reset-btn:hover {
+    border-color: var(--accent-color);
+    background-color: rgba(45, 186, 78, 0.1);
+    color: var(--accent-color);
+}
+
+body.dark-mode .color-reset-btn {
+    border-color: #30363d;
 }
 
 .message-author {

--- a/js/script.js
+++ b/js/script.js
@@ -47,8 +47,118 @@ document.addEventListener('DOMContentLoaded', () => {
     // Inicializa o tema
     initTheme();
 
+    // ==================== Card Color Personalization ====================
+
+    /**
+     * Gera a chave única para armazenar a cor de um card no localStorage
+     * @param {number} cardIndex - Índice do card
+     * @returns {string} Chave única no formato "card-color-{index}"
+     */
+    function getCardColorKey(cardIndex) {
+        return `card-color-${cardIndex}`;
+    }
+
+    /**
+     * Salva a cor personalizada de um card no localStorage
+     * @param {number} cardIndex - Índice do card
+     * @param {string} color - Cor em formato hex ou nome (ex: "#ff5500")
+     */
+    function saveCardColor(cardIndex, color) {
+        const key = getCardColorKey(cardIndex);
+        try {
+            localStorage.setItem(key, color);
+        } catch (error) {
+            console.warn(`Erro ao salvar cor do card ${cardIndex}:`, error);
+        }
+    }
+
+    /**
+     * Carrega a cor personalizada de um card do localStorage
+     * @param {number} cardIndex - Índice do card
+     * @returns {string|null} Cor salva ou null se não existir
+     */
+    function loadCardColor(cardIndex) {
+        const key = getCardColorKey(cardIndex);
+        try {
+            return localStorage.getItem(key);
+        } catch (error) {
+            console.warn(`Erro ao carregar cor do card ${cardIndex}:`, error);
+            return null;
+        }
+    }
+
+    /**
+     * Remove a cor personalizada de um card do localStorage
+     * @param {number} cardIndex - Índice do card
+     */
+    function resetCardColor(cardIndex) {
+        const key = getCardColorKey(cardIndex);
+        try {
+            localStorage.removeItem(key);
+        } catch (error) {
+            console.warn(`Erro ao resetar cor do card ${cardIndex}:`, error);
+        }
+    }
+
+    /**
+     * Aplica a cor (personalizada ou padrão) a um card
+     * @param {HTMLElement} cardElement - Elemento do card
+     * @param {number} cardIndex - Índice do card
+     * @param {string} defaultColor - Cor padrão da paleta
+     */
+    function applyCardColor(cardElement, cardIndex, defaultColor) {
+        const savedColor = loadCardColor(cardIndex);
+        const colorToApply = savedColor || defaultColor;
+        cardElement.style.borderTopColor = colorToApply;
+    }
+
+    /**
+     * Cria o color picker para personalizar a cor do card
+     * @param {HTMLElement} cardElement - Elemento do card
+     * @param {number} cardIndex - Índice do card
+     * @param {string} defaultColor - Cor padrão
+     * @returns {HTMLElement} Container com color picker e botão reset
+     */
+    function createColorPickerControl(cardElement, cardIndex, defaultColor) {
+        const container = document.createElement('div');
+        container.className = 'color-picker-control';
+
+        const colorInput = document.createElement('input');
+        colorInput.type = 'color';
+        colorInput.className = 'color-picker-input';
+        colorInput.setAttribute('aria-label', 'Escolher cor para o card');
+        colorInput.title = 'Personalizar cor do card';
+        
+        // Carrega a cor salva ou usa a padrão
+        const savedColor = loadCardColor(cardIndex);
+        colorInput.value = savedColor || defaultColor;
+
+        colorInput.addEventListener('change', (e) => {
+            const newColor = e.target.value;
+            saveCardColor(cardIndex, newColor);
+            applyCardColor(cardElement, cardIndex, newColor);
+        });
+
+        const resetButton = document.createElement('button');
+        resetButton.className = 'color-reset-btn';
+        resetButton.textContent = '↻';
+        resetButton.setAttribute('aria-label', 'Resetar cor para padrão');
+        resetButton.title = 'Resetar cor';
+
+        resetButton.addEventListener('click', (e) => {
+            e.preventDefault();
+            resetCardColor(cardIndex);
+            colorInput.value = defaultColor;
+            applyCardColor(cardElement, cardIndex, defaultColor);
+        });
+
+        container.appendChild(colorInput);
+        container.appendChild(resetButton);
+        return container;
+    }
+
     // ==================== Date-Based Seeding ====================
-    
+
     /**
      * Gera um valor seed consistente baseado na data do dia
      * Mesma data sempre gera o mesmo valor seed
@@ -59,7 +169,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const year = today.getFullYear();
         const month = today.getMonth();
         const day = today.getDate();
-        
+
         // Combina data em um número para seed
         const dayNumber = year * 10000 + (month + 1) * 100 + day;
         return dayNumber;
@@ -461,8 +571,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Usa uma cor da paleta extraída das imagens
         const colorIndex = index % colorPalette.length;
-        const borderColor = colorPalette[colorIndex];
-        card.style.borderTopColor = borderColor;
+        const defaultBorderColor = colorPalette[colorIndex];
+        
+        // Aplica cor personalizada ou padrão
+        applyCardColor(card, index, defaultBorderColor);
 
         const content = document.createElement('p');
         content.className = 'message-content';
@@ -472,12 +584,11 @@ document.addEventListener('DOMContentLoaded', () => {
         cardHeader.className = 'card-header';
         cardHeader.appendChild(content);
 
-        cardHeader.appendChild(createCopyButton(msg.message));
-
         const controls = document.createElement('div');
         controls.className = 'card-controls';
         controls.appendChild(createCopyButton(msg.message));
         controls.appendChild(createQRButton(msg.message));
+        controls.appendChild(createColorPickerControl(card, index, defaultBorderColor));
 
         cardHeader.appendChild(controls);
 


### PR DESCRIPTION
## 🎨 Descrição

Adiciona a capacidade de personalizar a cor da borda de cada card usando um color picker. As cores são salvas no localStorage e persistem entre sessões.

## ✨ Recursos Implementados

- ✅ Color picker input em cada card
- ✅ Salva cor personalizada no localStorage com chave única por card
- ✅ Carrega cor salva ao renderizar página (persistência)
- ✅ Botão reset para voltar à cor padrão da paleta
- ✅ Estilos responsivos com dark mode support
- ✅ Hover effects e transições suaves
- ✅ ARIA labels para acessibilidade
- ✅ Funções puras com responsabilidade única (Clean Code)

## 🎨 Mudanças

### JavaScript (js/script.js)
Funções novas:
- **getCardColorKey()** - Gera chave única para localStorage (card-color-{index})
- **saveCardColor()** - Persiste cor escolhida
- **loadCardColor()** - Carrega cor salva
- **resetCardColor()** - Remove cor personalizada
- **applyCardColor()** - Aplica cor ao elemento
- **createColorPickerControl()** - Factory para UI do color picker

Mudanças:
- **createMessageCard()** - Integra color picker controls e usa applyCardColor()

### CSS (css/style.css)
- **.card-controls** - Flex container para botões e color picker
- **.color-picker-input** - Estilos do color picker
- **.color-reset-btn** - Estilos do botão reset
- Dark mode support para ambos controles

## 🔗 Fecha
Fecha #5